### PR TITLE
Update config format to match other tools

### DIFF
--- a/MDXAsset.js
+++ b/MDXAsset.js
@@ -10,15 +10,10 @@ class MDXAsset extends Asset {
 
   async generate() {
     let config = await this.getConfig([
-      '.mdxconfigrc',
+      '.mdxrc',
       'mdx.config.js',
       'package.json',
-    ])
-    if (config.mdx) {
-      config = config.mdx
-    } else {
-      config = {}
-    }
+    ], {packageKey: 'mdx'})
     let compiled = await mdx(this.contents, config)
     let fullCode = `
 import React from 'react';


### PR DESCRIPTION
Awesome work on the plugin! Just a couple suggestions to make the config format match other configs used in Parcel.

1. `.mdxconfigrc` is a bit redundant, changed to `.mdxrc` to match other config filenames.
2. Used `packageKey` option to `getConfig` to get the `mdx` object.
3. Don't require `mdx` key in config files other than package.json since they are already specific to mdx.